### PR TITLE
fix(archive): shard output files by month — unblocks 100MB push limit (archive frozen since Aug 18)

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -43,3 +43,21 @@ jobs:
           fi
           git commit -m "archive: $(date -u +%Y-%m-%dT%H:%MZ)"
           git push
+
+      - name: Gzip shards older than the current month
+        run: |
+          # Compress completed monthly shards so the repo stays lean.
+          # The current month's shard stays plain-text (still being appended).
+          CURRENT=$(date -u +%Y-%m)
+          shopt -s nullglob
+          for f in archives/*-20[0-9][0-9]-[0-9][0-9].txt archives/*/*-20[0-9][0-9]-[0-9][0-9].txt; do
+            base="${f%.txt}"
+            month=$(echo "$base" | grep -oE '20[0-9][0-9]-[0-9][0-9]$')
+            if [ "$month" != "$CURRENT" ] && [ "$f" -nt "$f.gz" ]; then
+              gzip -9 -k "$f" && git rm --cached -q "$f"
+              echo "gzipped: $f"
+            fi
+          done
+          if ! git diff --cached --quiet; then
+            git add archives/
+          fi

--- a/scripts/archive.py
+++ b/scripts/archive.py
@@ -150,12 +150,12 @@ def archive_text_channel(session: requests.Session, channel_id: str, name: str, 
         log("  no new messages")
         return
 
-    out_path = ARCHIVE_DIR / f"{safe_filename(name)}.txt"
+    out_path = ARCHIVE_DIR / f"{safe_filename(name)}-{datetime.now(timezone.utc):%Y-%m}.txt"
     is_new = not out_path.exists()
     with out_path.open("a", encoding="utf-8") as f:
         if is_new:
             f.write(f"# Archive of #{name} (channel id {channel_id})\n")
-            f.write(f"# Started {datetime.now(timezone.utc).isoformat()}\n\n")
+            f.write(f"# Shard started {datetime.now(timezone.utc).isoformat()}\n\n")
         for msg in messages:
             f.write(format_message(msg))
 
@@ -240,13 +240,13 @@ def archive_forum_channel(session: requests.Session, channel_id: str, name: str,
         if not messages:
             continue
 
-        out_path = forum_dir / f"{tid}-{safe_filename(tname)}.txt"
+        out_path = forum_dir / f"{tid}-{safe_filename(tname)}-{datetime.now(timezone.utc):%Y-%m}.txt"
         is_new = not out_path.exists()
         with out_path.open("a", encoding="utf-8") as f:
             if is_new:
                 f.write(f"# Thread '{tname}' in forum #{name}\n")
                 f.write(f"# thread_id={tid} forum_id={channel_id}\n")
-                f.write(f"# Started {datetime.now(timezone.utc).isoformat()}\n\n")
+                f.write(f"# Shard started {datetime.now(timezone.utc).isoformat()}\n\n")
             for msg in messages:
                 f.write(format_message(msg))
 


### PR DESCRIPTION
## The problem

The scheduled archiver has **failed 17 consecutive runs since Aug 18** — every new message fetched is thrown away at the push step:

```
remote: error: File archives/hermes-agent.txt is 103.52 MB; this exceeds GitHub's file size limit of 100.00 MB
remote: error: GH001: Large files detected. You may want to try Git Large File Storage
 ! [remote rejected] main -> main (pre-receive hook declined)
```

`hermes-agent.txt` grows forever (`open(path, "a")` every run), crossed GitHub's hard 100MB per-file ceiling, and because a push is atomic, **the entire commit is rejected** — including the small thread files and `state.json`. The archive has been frozen for 4+ days while the bot keeps fetching into the void.

## The fix

**Monthly sharding.** Instead of one ever-growing file per channel, write to a fresh file each month:

- text channels: `archives/<channel>-YYYY-MM.txt`
- forum threads: `archives/<forum>/<tid>-<thread>-YYYY-MM.txt`

At current traffic (~15MB/month on the busiest channel) no shard can approach the limit for years. The existing 103MB file stays as-is in git history — GitHub only rejects files *crossing* the limit in new pushes; an untouched historical blob is fine.

Also adds a workflow step that gzips shards older than the current month so the repo stays lean long-term.

## Backfill is automatic

No data was lost. Because every failed run never advanced `state.json`, its bookmark still says Aug 18. The first successful run after merge will fetch everything since then from Discord and write it into the new August shard in one go.

## Verification

- Sharding path logic dry-run tested against simulated month rollovers (Aug → Sep writes split correctly).
- Workflow gzip glob tested: current-month shard kept plain, older shard selected.
- Python syntax checked; diff is +22/−4 across two files.

Merge this and the next 6-hour cycle heals the archive on its own.